### PR TITLE
Update nav_bar.dart and solved large title problem

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -1,7 +1,7 @@
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
+import 'dart:io';
 import 'dart:math' as math;
 import 'dart:ui' show ImageFilter;
 
@@ -878,6 +878,26 @@ class _LargeTitleNavigationBarSliverDelegate
     if (!transitionBetweenRoutes || !_isTransitionable(context)) {
       return navBar;
     }
+    
+    
+
+    int _iosSpecificLargeTitleResizer = 0;
+
+    
+    // this is added for declare ios version as int, i can get it directly, if you can please replace it
+    if (Platform.isIOS) {
+      final _iosVersion = int.tryParse(
+          Platform.operatingSystemVersion.split(' ')[1].split('.').first);
+      _iosSpecificLargeTitleResizer = ((_iosVersion ?? 15) < 14 ? 0 : 4);
+    }
+
+    //and here i have changed fontSize of textStyle for ios 14+
+    
+    TextStyle _transitionableNavigationBarTextStyle =
+        CupertinoTheme.of(context).textTheme.navLargeTitleTextStyle;
+    _transitionableNavigationBarTextStyle =
+        _transitionableNavigationBarTextStyle.copyWith(
+            fontSize: _transitionableNavigationBarTextStyle.fontSize! + 4);
 
     return Hero(
       tag: heroTag == _defaultHeroTag
@@ -892,10 +912,12 @@ class _LargeTitleNavigationBarSliverDelegate
       // needs to wrap the top level RenderBox rather than a RenderSliver.
       child: _TransitionableNavigationBar(
         componentsKeys: keys,
-        backgroundColor: CupertinoDynamicColor.resolve(backgroundColor, context),
-        backButtonTextStyle: CupertinoTheme.of(context).textTheme.navActionTextStyle,
+        backgroundColor:
+            CupertinoDynamicColor.resolve(backgroundColor, context),
+        backButtonTextStyle:
+            CupertinoTheme.of(context).textTheme.navActionTextStyle,
         titleTextStyle: CupertinoTheme.of(context).textTheme.navTitleTextStyle,
-        largeTitleTextStyle: CupertinoTheme.of(context).textTheme.navLargeTitleTextStyle,
+        largeTitleTextStyle: _transitionableNavigationBarTextStyle,
         border: border,
         hasUserMiddle: userMiddle != null,
         largeExpanded: showLargeTitle,


### PR DESCRIPTION
On ios devices which ios version is later than , when pop from page to previus page largeTitle showing us bad behavior about its size.

And now, below issues are fixed by this PR:
#67269


*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
